### PR TITLE
Add expense list components

### DIFF
--- a/packages/ui/src/expense-item.tsx
+++ b/packages/ui/src/expense-item.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { View, Text, StyleSheet } from "react-native";
+
+export interface ExpenseItemProps {
+  amount: number;
+  category: string;
+  description: string;
+  date: Date | string;
+}
+
+export function ExpenseItem({
+  amount,
+  category,
+  description,
+  date,
+}: ExpenseItemProps) {
+  const formattedDate = typeof date === "string" ? date : date.toDateString();
+  return (
+    <View style={styles.container}>
+      <Text style={styles.amount}>{amount.toFixed(2)}</Text>
+      <Text style={styles.category}>{category}</Text>
+      <Text style={styles.description}>{description}</Text>
+      <Text style={styles.date}>{formattedDate}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    borderBottomWidth: 1,
+    borderColor: "#ccc",
+  },
+  amount: {
+    fontWeight: "bold",
+    marginRight: 8,
+  },
+  category: {
+    flex: 1,
+  },
+  description: {
+    flex: 2,
+  },
+  date: {
+    marginLeft: 8,
+  },
+});

--- a/packages/ui/src/expense-list.tsx
+++ b/packages/ui/src/expense-list.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { View, StyleSheet } from "react-native";
+
+export interface ExpenseListProps {
+  children: React.ReactNode;
+}
+
+export function ExpenseList({ children }: ExpenseListProps) {
+  return <View style={styles.container}>{children}</View>;
+}
+
+const styles = StyleSheet.create({
+  container: {
+    width: "100%",
+  },
+});

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -8,3 +8,5 @@ export {
   SignupForm,
   type SignupFormProps,
 } from "./auth-form";
+export { ExpenseItem, type ExpenseItemProps } from "./expense-item";
+export { ExpenseList, type ExpenseListProps } from "./expense-list";


### PR DESCRIPTION
## Summary
- add `ExpenseItem` reusable row component
- add `ExpenseList` wrapper component
- export new components from `@repo/ui`

## Testing
- `NEXT_TELEMETRY_DISABLED=1 yarn build`


------
https://chatgpt.com/codex/tasks/task_e_688b989b2acc8320bec364bc275b9cba