### PR TITLE
Add login and signup screens

### DIFF
--- a/apps/native/app/index.tsx
+++ b/apps/native/app/index.tsx
@@ -1,12 +1,17 @@
 import { StyleSheet, Text, View } from "react-native";
 import { StatusBar } from "expo-status-bar";
-import {AuthForm} from "@repo/ui/src";
+import { Button } from "@repo/ui";
+import { useUser } from "@repo/context/src";
+import { Link } from "expo-router";
 
 export default function Native() {
+  const { user } = useUser();
   return (
     <View style={styles.container}>
       <Text style={styles.header}>Native</Text>
-        <AuthForm submitButtonText={"Login"} onSubmit={() => alert("LoginFormSubmitted")} />
+      {user && <Text style={styles.user}>Logged in as {user.email}</Text>}
+      <Button onClick={() => console.log("Pressed!")} text="Boop" />
+      <Link href="/login" style={styles.link}>login</Link>
       <StatusBar style="auto" />
     </View>
   );
@@ -18,10 +23,17 @@ const styles = StyleSheet.create({
     backgroundColor: "#fff",
     alignItems: "center",
     justifyContent: "center",
+    paddingHorizontal: 16,
   },
   header: {
     fontWeight: "bold",
     marginBottom: 20,
     fontSize: 36,
+  },
+  user: {
+    marginBottom: 12,
+  },
+  link: {
+    marginTop: 12,
   },
 });

--- a/apps/native/app/login.tsx
+++ b/apps/native/app/login.tsx
@@ -1,0 +1,37 @@
+import { StyleSheet, Text, View } from "react-native";
+import { Link, useRouter } from "expo-router";
+import { LoginForm } from "@repo/ui/src";
+
+export default function LoginScreen() {
+  const router = useRouter();
+
+  const onLogin = () => {
+    router.push("/");
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.header}>Login</Text>
+      <LoginForm onSubmit={onLogin} />
+      <Link href="/signup" style={styles.link}>signup</Link>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#fff",
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 16,
+  },
+  header: {
+    fontWeight: "bold",
+    marginBottom: 20,
+    fontSize: 36,
+  },
+  link: {
+    marginTop: 12,
+  },
+});

--- a/apps/native/app/signup.tsx
+++ b/apps/native/app/signup.tsx
@@ -1,0 +1,37 @@
+import { StyleSheet, Text, View } from "react-native";
+import { Link, useRouter } from "expo-router";
+import { SignupForm } from "@repo/ui/src";
+
+export default function SignupScreen() {
+  const router = useRouter();
+
+  const onSignup = () => {
+    router.push("/");
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.header}>Signup</Text>
+      <SignupForm onSubmit={onSignup} />
+      <Link href="/login" style={styles.link}>login</Link>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#fff",
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 16,
+  },
+  header: {
+    fontWeight: "bold",
+    marginBottom: 20,
+    fontSize: 36,
+  },
+  link: {
+    marginTop: 12,
+  },
+});

--- a/packages/ui/src/auth/login-form.tsx
+++ b/packages/ui/src/auth/login-form.tsx
@@ -1,7 +1,8 @@
 "use client";
 
+import React from "react";
 import { useUser } from "@repo/context/src";
-import { AuthForm } from "./auth-form";
+import { AuthForm, type AuthFormValues } from "./auth-form";
 
 export interface LoginFormProps {
   onSubmit?: () => void;
@@ -9,9 +10,10 @@ export interface LoginFormProps {
 
 export function LoginForm({ onSubmit }: LoginFormProps) {
   const { setUser } = useUser();
-  const onLogin = (values) => {
+  const onLogin = (values: AuthFormValues) => {
     setUser({ email: values.email, name: values.email });
     onSubmit && onSubmit();
-  }
+  };
   return <AuthForm submitButtonText="Login" onSubmit={onLogin} />;
 }
+

--- a/packages/ui/src/auth/signup-form.tsx
+++ b/packages/ui/src/auth/signup-form.tsx
@@ -1,4 +1,5 @@
-import { AuthForm } from "./auth-form";
+import React from "react";
+import { AuthForm, type AuthFormValues } from "./auth-form";
 import { useUser } from "@repo/context/src";
 
 export interface SignupFormProps {
@@ -7,10 +8,10 @@ export interface SignupFormProps {
 
 export function SignupForm({ onSubmit }: SignupFormProps) {
   const { setUser } = useUser();
-  const onSignup = (values) => {
+  const onSignup = (values: AuthFormValues) => {
     setUser({ email: values.email, name: values.email });
     onSubmit && onSubmit();
-  }
+  };
   return (
     <AuthForm
       includeConfirmPassword
@@ -19,3 +20,4 @@ export function SignupForm({ onSubmit }: SignupFormProps) {
     />
   );
 }
+


### PR DESCRIPTION
## Summary
- create dedicated login and signup screens for the native app
- show a small home screen with a link to login
- fix typing in UI login and signup forms

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_688baaaff8a08320945724ff4bf32962