### PR TITLE
Add simple validation to AuthForm

### DIFF
--- a/packages/ui/src/auth/auth-form.tsx
+++ b/packages/ui/src/auth/auth-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState } from "react";
-import { View, TextInput, StyleSheet } from "react-native";
+import { View, TextInput, StyleSheet, Alert } from "react-native";
 import { Button } from "../button";
 
 export interface AuthFormValues {
@@ -26,6 +26,15 @@ export function AuthForm({
   const [confirmPassword, setConfirmPassword] = useState("");
 
   function handleSubmit() {
+    if (!email || !password || (includeConfirmPassword && !confirmPassword)) {
+      Alert.alert("All fields are required");
+      return;
+    }
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email)) {
+      Alert.alert("Invalid email address");
+      return;
+    }
     const values: AuthFormValues = { email, password };
     if (includeConfirmPassword) {
       values.confirmPassword = confirmPassword;
@@ -68,7 +77,7 @@ const styles = StyleSheet.create({
     width: "100%",
     maxWidth: 320,
     marginStart: "auto",
-    marginEnd: "auto"
+    marginEnd: "auto",
   },
   input: {
     borderWidth: 1,
@@ -79,4 +88,3 @@ const styles = StyleSheet.create({
     marginBottom: 12,
   },
 });
-

--- a/packages/ui/src/auth/auth-form.tsx
+++ b/packages/ui/src/auth/auth-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState } from "react";
-import { View, TextInput, StyleSheet, Alert } from "react-native";
+import { View, TextInput, StyleSheet, Text } from "react-native";
 import { Button } from "../button";
 
 export interface AuthFormValues {
@@ -25,16 +25,43 @@ export function AuthForm({
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
 
+  const [emailError, setEmailError] = useState("");
+  const [passwordError, setPasswordError] = useState("");
+  const [confirmPasswordError, setConfirmPasswordError] = useState("");
+
   function handleSubmit() {
-    if (!email || !password || (includeConfirmPassword && !confirmPassword)) {
-      Alert.alert("All fields are required");
+    let valid = true;
+    setEmailError("");
+    setPasswordError("");
+    setConfirmPasswordError("");
+
+    if (!email) {
+      setEmailError("Email is required");
+      valid = false;
+    } else {
+      const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+      if (!emailRegex.test(email)) {
+        setEmailError("Invalid email address");
+        valid = false;
+      }
+    }
+
+    if (!password) {
+      setPasswordError("Password is required");
+      valid = false;
+    }
+
+    if (includeConfirmPassword) {
+      if (!confirmPassword) {
+        setConfirmPasswordError("Confirm password is required");
+        valid = false;
+      }
+    }
+
+    if (!valid) {
       return;
     }
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    if (!emailRegex.test(email)) {
-      Alert.alert("Invalid email address");
-      return;
-    }
+
     const values: AuthFormValues = { email, password };
     if (includeConfirmPassword) {
       values.confirmPassword = confirmPassword;
@@ -48,24 +75,42 @@ export function AuthForm({
         style={styles.input}
         placeholder="Email"
         value={email}
-        onChangeText={setEmail}
+        onChangeText={(text) => {
+          setEmail(text);
+          if (emailError) setEmailError("");
+        }}
         autoCapitalize="none"
       />
+      {emailError ? <Text style={styles.errorText}>{emailError}</Text> : null}
       <TextInput
         style={styles.input}
         placeholder="Password"
         value={password}
-        onChangeText={setPassword}
+        onChangeText={(text) => {
+          setPassword(text);
+          if (passwordError) setPasswordError("");
+        }}
         secureTextEntry
       />
+      {passwordError ? (
+        <Text style={styles.errorText}>{passwordError}</Text>
+      ) : null}
       {includeConfirmPassword && (
-        <TextInput
-          style={styles.input}
-          placeholder="Confirm Password"
-          value={confirmPassword}
-          onChangeText={setConfirmPassword}
-          secureTextEntry
-        />
+        <>
+          <TextInput
+            style={styles.input}
+            placeholder="Confirm Password"
+            value={confirmPassword}
+            onChangeText={(text) => {
+              setConfirmPassword(text);
+              if (confirmPasswordError) setConfirmPasswordError("");
+            }}
+            secureTextEntry
+          />
+          {confirmPasswordError ? (
+            <Text style={styles.errorText}>{confirmPasswordError}</Text>
+          ) : null}
+        </>
       )}
       <Button text={submitButtonText} onClick={handleSubmit} />
     </View>
@@ -86,5 +131,9 @@ const styles = StyleSheet.create({
     paddingVertical: 8,
     paddingHorizontal: 12,
     marginBottom: 12,
+  },
+  errorText: {
+    color: "#e53935",
+    marginBottom: 8,
   },
 });


### PR DESCRIPTION
## Summary
- add react-native `Alert` to auth form
- validate required fields and basic email format

## Testing
- `yarn format`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_688bae9c0b6483208ccd6af162a9313a