### PR TITLE
Add dummy auth API routes

### DIFF
--- a/apps/web/app/api/login/route.ts
+++ b/apps/web/app/api/login/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from "next/server";
+
+export async function POST(request: Request) {
+  return NextResponse.json({ success: true });
+}

--- a/apps/web/app/api/signup/route.ts
+++ b/apps/web/app/api/signup/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from "next/server";
+
+export async function POST(request: Request) {
+  return NextResponse.json({ success: true });
+}

--- a/apps/web/components/LoginForm.tsx
+++ b/apps/web/components/LoginForm.tsx
@@ -6,7 +6,8 @@ import { useRouter } from "next/navigation";
 
 export function LoginForm() {
     const router = useRouter();
-    const onLogin = () => {
+    const onLogin = async () => {
+        await fetch("/api/login", { method: "POST" });
         router.push("/");
     }
     return (

--- a/apps/web/components/SignupForm.tsx
+++ b/apps/web/components/SignupForm.tsx
@@ -6,7 +6,8 @@ import { useRouter } from "next/navigation";
 
 export function SignupForm() {
     const router = useRouter();
-    const onSignup = () => {
+    const onSignup = async () => {
+        await fetch("/api/signup", { method: "POST" });
         router.push("/");
     }
     return (
@@ -14,7 +15,7 @@ export function SignupForm() {
             <h1>Signup</h1>
             <Form onSubmit={onSignup}/>
             or
-            <Link href="/login">signup</Link>
+            <Link href="/login">login</Link>
         </div>
     )
 }


### PR DESCRIPTION
## Summary
- add stub login and signup API routes
- invoke API routes from login and signup forms

## Testing
- `yarn lint` in `apps/web`


------
https://chatgpt.com/codex/tasks/task_e_688baf3138f0832092106d62ad9fd478