### PR TITLE
Add filtering and sorting to dashboard

### DIFF
--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -1,8 +1,8 @@
 import styles from "../../styles/index.module.css";
-import { ExpenseList } from "@repo/ui";
-import { ExpenseItem, ExpenseItemProps } from "@repo/ui/src";
+import { ExpenseItemProps } from "@repo/ui/src";
+import { DashboardClient } from "../../components";
 
-async function getData() {
+async function getExpenses() {
   const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/expenses`, {
     method: "GET",
   });
@@ -10,20 +10,28 @@ async function getData() {
   return data;
 }
 
+async function getCategories() {
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_API_URL}/expense-categories`,
+    {
+      method: "GET",
+    }
+  );
+  const { data } = await res.json();
+  return data as string[];
+}
+
 export default async function Dashboard() {
-  const data = (await getData()) as ExpenseItemProps[];
+  const expenses = (await getExpenses()) as ExpenseItemProps[];
+  const categories = await getCategories();
 
   return (
     <div className={styles.container}>
       <h1>Your Smartest Money Habit Starts Here</h1>
       <p></p>
-      {data.length && (
-        <ExpenseList>
-          {data.map((item, index) => (
-            <ExpenseItem key={`${item.category}-${index}`} {...item} />
-          ))}
-        </ExpenseList>
-      )}
+      {expenses.length ? (
+        <DashboardClient expenses={expenses} categories={categories} />
+      ) : null}
     </div>
   );
 }

--- a/apps/web/components/DashboardClient.tsx
+++ b/apps/web/components/DashboardClient.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { ExpenseList, ExpenseItem, ExpenseItemProps } from "@repo/ui";
+
+export interface DashboardClientProps {
+  expenses: ExpenseItemProps[];
+  categories: string[];
+}
+
+export function DashboardClient({ expenses, categories }: DashboardClientProps) {
+  const [selectedCategory, setSelectedCategory] = useState<string>("All");
+  const [sortBy, setSortBy] = useState<"date" | "amount">("date");
+
+  const filteredExpenses = useMemo(() => {
+    let result = expenses;
+    if (selectedCategory !== "All") {
+      result = result.filter((e) => e.category === selectedCategory);
+    }
+    result = [...result].sort((a, b) => {
+      if (sortBy === "amount") {
+        return a.amount - b.amount;
+      }
+      return new Date(a.date).getTime() - new Date(b.date).getTime();
+    });
+    return result;
+  }, [expenses, selectedCategory, sortBy]);
+
+  return (
+    <div>
+      <div style={{ display: "flex", gap: "8px", marginBottom: 16 }}>
+        <select
+          value={selectedCategory}
+          onChange={(e) => setSelectedCategory(e.target.value)}
+        >
+          <option value="All">All Categories</option>
+          {categories.map((cat) => (
+            <option key={cat} value={cat}>
+              {cat}
+            </option>
+          ))}
+        </select>
+        <select
+          value={sortBy}
+          onChange={(e) => setSortBy(e.target.value as "date" | "amount")}
+        >
+          <option value="date">Date</option>
+          <option value="amount">Amount</option>
+        </select>
+      </div>
+      <ExpenseList>
+        {filteredExpenses.map((item, index) => (
+          <ExpenseItem key={`${item.category}-${index}`} {...item} />
+        ))}
+      </ExpenseList>
+    </div>
+  );
+}

--- a/apps/web/components/index.ts
+++ b/apps/web/components/index.ts
@@ -1,2 +1,3 @@
-export { LoginForm } from "./LoginForm";
-export { SignupForm } from "./SignupForm";
+export { LoginForm } from './LoginForm';
+export { SignupForm } from './SignupForm';
+export { DashboardClient } from './DashboardClient';


### PR DESCRIPTION
## Summary
- add `DashboardClient` component with category filtering and sort selectors
- fetch expenses and categories for dashboard page and render with new component
- re-export `DashboardClient`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688cce489810832081adcd72697a1715