### PR TITLE
Add total spending statistic block

### DIFF
--- a/apps/web/components/DashboardClient.tsx
+++ b/apps/web/components/DashboardClient.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useMemo } from "react";
-import { ExpenseList, ExpenseItem, ExpenseItemProps } from "@repo/ui";
+import { ExpenseList, ExpenseItem, StatisticBlock, ExpenseItemProps } from "@repo/ui";
 
 export interface DashboardClientProps {
   expenses: ExpenseItemProps[];
@@ -11,6 +11,11 @@ export interface DashboardClientProps {
 export function DashboardClient({ expenses, categories }: DashboardClientProps) {
   const [selectedCategory, setSelectedCategory] = useState<string>("All");
   const [sortBy, setSortBy] = useState<"date" | "amount">("date");
+
+  const totalSpending = useMemo(
+    () => expenses.reduce((sum, e) => sum + e.amount, 0),
+    [expenses]
+  );
 
   const filteredExpenses = useMemo(() => {
     let result = expenses;
@@ -28,6 +33,10 @@ export function DashboardClient({ expenses, categories }: DashboardClientProps) 
 
   return (
     <div>
+      <StatisticBlock
+        label="Total Spending"
+        value={`$${totalSpending.toFixed(2)}`}
+      />
       <div style={{ display: "flex", gap: "8px", marginBottom: 16 }}>
         <select
           value={selectedCategory}

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -1,3 +1,4 @@
 export { Button, type ButtonProps } from "./button";
 export * from "./auth";
 export * from "./expenses";
+export * from "./statistics";

--- a/packages/ui/src/statistics/index.tsx
+++ b/packages/ui/src/statistics/index.tsx
@@ -1,0 +1,1 @@
+export { StatisticBlock, type StatisticBlockProps } from './statistic-block';

--- a/packages/ui/src/statistics/statistic-block.tsx
+++ b/packages/ui/src/statistics/statistic-block.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export interface StatisticBlockProps {
+  label: string;
+  value: string | number;
+}
+
+export function StatisticBlock({ label, value }: StatisticBlockProps) {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.label}>{label}</Text>
+      <Text style={styles.value}>{value}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginBottom: 16,
+    alignItems: 'center',
+  },
+  label: {
+    fontSize: 16,
+    color: '#666',
+  },
+  value: {
+    fontSize: 24,
+    fontWeight: 'bold',
+  },
+});


### PR DESCRIPTION
## Summary
- add StatisticBlock component in `@repo/ui`
- export statistics components
- show total spending amount on the dashboard

## Testing
- `yarn build` *(fails: fetch failed during prerender)*

------
https://chatgpt.com/codex/tasks/task_e_688cf31ee1d883209612848cb9a34c5f