### PR TITLE
Add React Native dropdown to dashboard

### DIFF
--- a/apps/web/components/DashboardClient.tsx
+++ b/apps/web/components/DashboardClient.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import { useState, useMemo } from "react";
-import { ExpenseList, ExpenseItem, StatisticBlock, ExpenseItemProps } from "@repo/ui";
+import {
+  ExpenseList,
+  ExpenseItem,
+  StatisticBlock,
+  Dropdown,
+  ExpenseItemProps,
+} from "@repo/ui";
 import { ExportToCsvButton } from "./ExportToCsvButton";
 
 export interface DashboardClientProps {
@@ -18,7 +24,7 @@ export function DashboardClient({
 
   const totalSpending = useMemo(
     () => expenses.reduce((sum, e) => sum + e.amount, 0),
-    [expenses]
+    [expenses],
   );
 
   const filteredExpenses = useMemo(() => {
@@ -42,24 +48,22 @@ export function DashboardClient({
         value={`$${totalSpending.toFixed(2)}`}
       />
       <div style={{ display: "flex", gap: "8px", marginBottom: 16 }}>
-        <select
+        <Dropdown
           value={selectedCategory}
-          onChange={(e) => setSelectedCategory(e.target.value)}
-        >
-          <option value="All">All Categories</option>
-          {categories.map((cat) => (
-            <option key={cat} value={cat}>
-              {cat}
-            </option>
-          ))}
-        </select>
-        <select
+          onChange={setSelectedCategory}
+          options={[
+            { label: "All Categories", value: "All" },
+            ...categories.map((cat) => ({ label: cat, value: cat })),
+          ]}
+        />
+        <Dropdown
           value={sortBy}
-          onChange={(e) => setSortBy(e.target.value as "date" | "amount")}
-        >
-          <option value="date">Date</option>
-          <option value="amount">Amount</option>
-        </select>
+          onChange={(v) => setSortBy(v as "date" | "amount")}
+          options={[
+            { label: "Date", value: "date" },
+            { label: "Amount", value: "amount" },
+          ]}
+        />
         <ExportToCsvButton expenses={filteredExpenses} />
       </div>
       <ExpenseList>

--- a/packages/ui/src/dropdown-menu/Dropdown.tsx
+++ b/packages/ui/src/dropdown-menu/Dropdown.tsx
@@ -92,3 +92,4 @@ const styles = StyleSheet.create({
     elevation: 4,
   },
 });
+export default DropdownMenu;

--- a/packages/ui/src/dropdown/Dropdown.tsx
+++ b/packages/ui/src/dropdown/Dropdown.tsx
@@ -1,0 +1,66 @@
+import React, { useState } from "react";
+import { View, Text, StyleSheet } from "react-native";
+import DropdownMenu from "../dropdown-menu/Dropdown";
+import { MenuOption } from "../dropdown-menu/DropdownOption";
+
+export interface DropdownOption<T> {
+  label: string;
+  value: T;
+}
+
+export interface DropdownProps<T> {
+  value: T;
+  onChange: (value: T) => void;
+  options: DropdownOption<T>[];
+  width?: number;
+}
+
+export function Dropdown<T extends string | number>({
+  value,
+  onChange,
+  options,
+  width,
+}: DropdownProps<T>) {
+  const [open, setOpen] = useState(false);
+  const selectedLabel =
+    options.find((o) => o.value === value)?.label ?? String(value);
+
+  return (
+    <DropdownMenu
+      visible={open}
+      handleOpen={() => setOpen(true)}
+      handleClose={() => setOpen(false)}
+      trigger={
+        <View style={[styles.trigger, width ? { width } : undefined]}>
+          <Text>{selectedLabel}</Text>
+        </View>
+      }
+      dropdownWidth={width}
+    >
+      {options.map((opt) => (
+        <MenuOption
+          key={String(opt.value)}
+          onSelect={() => {
+            onChange(opt.value);
+            setOpen(false);
+          }}
+        >
+          <Text>{opt.label}</Text>
+        </MenuOption>
+      ))}
+    </DropdownMenu>
+  );
+}
+
+const styles = StyleSheet.create({
+  trigger: {
+    borderWidth: 1,
+    borderColor: "#ccc",
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    borderRadius: 4,
+    backgroundColor: "white",
+  },
+});
+
+export default Dropdown;

--- a/packages/ui/src/dropdown/index.tsx
+++ b/packages/ui/src/dropdown/index.tsx
@@ -1,0 +1,1 @@
+export { Dropdown, type DropdownProps, type DropdownOption } from "./Dropdown";

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -2,3 +2,4 @@ export { Button, type ButtonProps } from "./button";
 export * from "./auth";
 export * from "./expenses";
 export * from "./statistics";
+export * from "./dropdown";


### PR DESCRIPTION
## Summary
- implement a generic `Dropdown` component in `@repo/ui`
- export `Dropdown` from ui package
- update `DashboardClient` to use the new component
- expose default export from existing `DropdownMenu`

## Testing
- `yarn build` *(fails: Type error in unmodified login route)*

------
https://chatgpt.com/codex/tasks/task_e_688d12a8003c83208f6820306c842923