### PR TITLE
Create React Native dropdown for dashboard filters

### DIFF
--- a/apps/web/components/DashboardClient.tsx
+++ b/apps/web/components/DashboardClient.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import { useState, useMemo } from "react";
-import { ExpenseList, ExpenseItem, StatisticBlock, ExpenseItemProps } from "@repo/ui";
+import {
+  ExpenseList,
+  ExpenseItem,
+  StatisticBlock,
+  Dropdown,
+  type ExpenseItemProps,
+} from "@repo/ui";
 import { ExportToCsvButton } from "./ExportToCsvButton";
 
 export interface DashboardClientProps {
@@ -18,7 +24,7 @@ export function DashboardClient({
 
   const totalSpending = useMemo(
     () => expenses.reduce((sum, e) => sum + e.amount, 0),
-    [expenses]
+    [expenses],
   );
 
   const filteredExpenses = useMemo(() => {
@@ -42,24 +48,22 @@ export function DashboardClient({
         value={`$${totalSpending.toFixed(2)}`}
       />
       <div style={{ display: "flex", gap: "8px", marginBottom: 16 }}>
-        <select
+        <Dropdown
           value={selectedCategory}
-          onChange={(e) => setSelectedCategory(e.target.value)}
-        >
-          <option value="All">All Categories</option>
-          {categories.map((cat) => (
-            <option key={cat} value={cat}>
-              {cat}
-            </option>
-          ))}
-        </select>
-        <select
+          onChange={setSelectedCategory}
+          options={[
+            { label: "All Categories", value: "All" },
+            ...categories.map((cat) => ({ label: cat, value: cat })),
+          ]}
+        />
+        <Dropdown
           value={sortBy}
-          onChange={(e) => setSortBy(e.target.value as "date" | "amount")}
-        >
-          <option value="date">Date</option>
-          <option value="amount">Amount</option>
-        </select>
+          onChange={(v) => setSortBy(v as "date" | "amount")}
+          options={[
+            { label: "Date", value: "date" },
+            { label: "Amount", value: "amount" },
+          ]}
+        />
         <ExportToCsvButton expenses={filteredExpenses} />
       </div>
       <ExpenseList>

--- a/packages/ui/src/dropdown.tsx
+++ b/packages/ui/src/dropdown.tsx
@@ -1,0 +1,90 @@
+import React, { useState } from "react";
+import {
+  View,
+  Text,
+  Pressable,
+  StyleSheet,
+  Modal,
+  ScrollView,
+} from "react-native";
+
+export interface DropdownOption {
+  label: string;
+  value: string;
+}
+
+export interface DropdownProps {
+  options: DropdownOption[];
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+}
+
+export function Dropdown({
+  options,
+  value,
+  onChange,
+  placeholder = "Select",
+}: DropdownProps) {
+  const [open, setOpen] = useState(false);
+
+  const selectedLabel =
+    options.find((o) => o.value === value)?.label ?? placeholder;
+
+  return (
+    <View>
+      <Pressable style={styles.trigger} onPress={() => setOpen(true)}>
+        <Text>{selectedLabel}</Text>
+      </Pressable>
+      <Modal
+        transparent
+        visible={open}
+        animationType="fade"
+        onRequestClose={() => setOpen(false)}
+      >
+        <Pressable style={styles.overlay} onPress={() => setOpen(false)}>
+          <View style={styles.menu}>
+            <ScrollView>
+              {options.map((opt) => (
+                <Pressable
+                  key={opt.value}
+                  style={styles.option}
+                  onPress={() => {
+                    onChange(opt.value);
+                    setOpen(false);
+                  }}
+                >
+                  <Text>{opt.label}</Text>
+                </Pressable>
+              ))}
+            </ScrollView>
+          </View>
+        </Pressable>
+      </Modal>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  trigger: {
+    padding: 8,
+    borderWidth: 1,
+    borderColor: "#ccc",
+    borderRadius: 4,
+  },
+  overlay: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    backgroundColor: "rgba(0,0,0,0.3)",
+  },
+  menu: {
+    backgroundColor: "white",
+    borderRadius: 4,
+    width: 150,
+    maxHeight: 200,
+  },
+  option: {
+    padding: 8,
+  },
+});

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -2,3 +2,4 @@ export { Button, type ButtonProps } from "./button";
 export * from "./auth";
 export * from "./expenses";
 export * from "./statistics";
+export { Dropdown, type DropdownProps, type DropdownOption } from "./dropdown";


### PR DESCRIPTION
## Summary
- add a cross-platform `Dropdown` component in the UI package
- export the new component from `@repo/ui`
- replace HTML selects in `DashboardClient` with the new React Native dropdowns

## Testing
- `npx prettier apps/web/components/DashboardClient.tsx packages/ui/src/index.tsx packages/ui/src/dropdown.tsx -w`

------
https://chatgpt.com/codex/tasks/task_e_688d12a8003c83208f6820306c842923