### PR TITLE
Fix native login and signup

### DIFF
--- a/apps/native/.env
+++ b/apps/native/.env
@@ -1,0 +1,1 @@
+EXPO_PUBLIC_API_URL=https://web-and-native-expense-tracker.vercel.app/api

--- a/apps/native/app/login.tsx
+++ b/apps/native/app/login.tsx
@@ -1,19 +1,47 @@
 import { StyleSheet, Text, View } from "react-native";
 import { Link, useRouter } from "expo-router";
-import { LoginForm } from "@repo/ui/src";
+import { useState } from "react";
+import { AuthForm, type AuthFormValues } from "@repo/ui/src";
+import { useUser } from "@repo/context/src";
 
 export default function LoginScreen() {
   const router = useRouter();
+  const { setUser } = useUser();
+  const [errorMessage, setErrorMessage] = useState("");
 
-  const onLogin = () => {
+  const onLogin = async (values: AuthFormValues) => {
+    const response = await fetch(`${process.env.EXPO_PUBLIC_API_URL}/login`, {
+      method: "POST",
+      body: JSON.stringify({
+        email: values.email,
+        password: values.password,
+      }),
+    });
+    const data = await response.json();
+
+    if (!response.ok) {
+      setErrorMessage(
+        data?.error ||
+          "Something went wrong. Please try again in a few minutes.",
+      );
+      return;
+    }
+
+    setUser({ email: values.email, name: values.email });
     router.push("/");
   };
 
   return (
     <View style={styles.container}>
       <Text style={styles.header}>Login</Text>
-      <LoginForm onSubmit={onLogin} />
-      <Link href="/signup" style={styles.link}>signup</Link>
+      <AuthForm
+        submitButtonText="Login"
+        onSubmit={onLogin}
+        errorMessage={errorMessage}
+      />
+      <Link href="/signup" style={styles.link}>
+        signup
+      </Link>
     </View>
   );
 }

--- a/apps/native/app/signup.tsx
+++ b/apps/native/app/signup.tsx
@@ -1,19 +1,48 @@
 import { StyleSheet, Text, View } from "react-native";
 import { Link, useRouter } from "expo-router";
-import { SignupForm } from "@repo/ui/src";
+import { useState } from "react";
+import { AuthForm, type AuthFormValues } from "@repo/ui/src";
+import { useUser } from "@repo/context/src";
 
 export default function SignupScreen() {
   const router = useRouter();
+  const { setUser } = useUser();
+  const [errorMessage, setErrorMessage] = useState("");
 
-  const onSignup = () => {
+  const onSignup = async (values: AuthFormValues) => {
+    const response = await fetch(`${process.env.EXPO_PUBLIC_API_URL}/signup`, {
+      method: "POST",
+      body: JSON.stringify({
+        email: values.email,
+        password: values.password,
+      }),
+    });
+    const data = await response.json();
+
+    if (!response.ok) {
+      setErrorMessage(
+        data?.error ||
+          "Something went wrong. Please try again in a few minutes.",
+      );
+      return;
+    }
+
+    setUser({ email: values.email, name: values.email });
     router.push("/");
   };
 
   return (
     <View style={styles.container}>
       <Text style={styles.header}>Signup</Text>
-      <SignupForm onSubmit={onSignup} />
-      <Link href="/login" style={styles.link}>login</Link>
+      <AuthForm
+        includeConfirmPassword
+        submitButtonText="Sign Up"
+        onSubmit={onSignup}
+        errorMessage={errorMessage}
+      />
+      <Link href="/login" style={styles.link}>
+        login
+      </Link>
     </View>
   );
 }


### PR DESCRIPTION
## Summary
- update Login and Signup screens in the native app to submit to the hosted API
- add `.env` for native app with API URL

## Testing
- `prettier --check apps/native/app/login.tsx apps/native/app/signup.tsx`
- `yarn build` *(fails: Parameter 'req' implicitly has an 'any' type)*

------
https://chatgpt.com/codex/tasks/task_e_688d13157d8c8320a31155ae6aea5e4e