### PR TITLE
docs: update readme files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,63 @@
-# Turborepo react-native starter
+# Web and Native Expense Tracker
 
-This is a community-maintained example. If you experience a problem, please submit a pull request with a fix. GitHub Issues will be closed.
+Monorepo for a simple expense tracker with web and mobile clients. The project uses **Turborepo** to share code between a Next.js web app and an Expo-powered React Native app.
 
-## Using this example
+## Apps and Packages
 
-Run the following command:
+- `apps/web` – Next.js app using React Native Web
+- `apps/native` – Expo app for iOS, Android, and web
+- `packages/ui` – shared React Native components
+- `packages/context` – shared state and hooks
+- `packages/typescript-config` – base `tsconfig` for all apps and packages
 
-```sh
-npx create-turbo@latest -e with-react-native-web
+## Development
+
+Install dependencies and start both apps from the repository root:
+
+```bash
+yarn install
+yarn dev
 ```
 
-## What's inside?
+`yarn dev` runs the web app at http://localhost:3000 and starts Expo for the native app. You can also start each app individually:
 
-This Turborepo includes the following packages/apps:
+```bash
+# Web
+cd apps/web
+yarn dev
 
-### Apps and Packages
+# Native
+cd apps/native
+yarn dev        # or yarn ios / yarn android
+```
 
-- `native`: a [react-native](https://reactnative.dev/) app built with [expo](https://docs.expo.dev/)
-- `web`: a [Next.js](https://nextjs.org/) app built with [react-native-web](https://necolas.github.io/react-native-web/)
-- `@repo/ui`: a stub [react-native](https://reactnative.dev/) component library shared by both `web` and `native` applications
-- `@repo/typescript-config`: `tsconfig.json`s used throughout the monorepo
+## Environment Variables
 
-Each package/app is 100% [TypeScript](https://www.typescriptlang.org/).
+Create `.env` files inside each app with the following variables:
 
-### Utilities
+```bash
+# apps/web/.env
+NEXT_PUBLIC_SUPABASE_URL=
+NEXT_PUBLIC_SUPABASE_ANON_KEY=
+NEXT_PUBLIC_API_URL=
 
-This Turborepo has some additional tools already setup for you:
+# apps/native/.env
+API_URL=
+```
 
-- [Expo](https://docs.expo.dev/) for native development
-- [TypeScript](https://www.typescriptlang.org/) for static type checking
-- [Prettier](https://prettier.io) for code formatting
+`NEXT_PUBLIC_*` variables expose Supabase credentials and the API base URL for the web app. `API_URL` provides the backend endpoint for the native app.
+
+## Formatting and Building
+
+Format source files with Prettier and build all packages and apps using Turbo:
+
+```bash
+yarn format
+yarn build
+```
+
+## Features
+
+- User authentication (login & signup)
+- Dashboard for tracking expenses and categories
+- Shared UI components and context across web and native clients

--- a/apps/native/README.md
+++ b/apps/native/README.md
@@ -1,3 +1,25 @@
-# Native
+# Native App
 
-A [react-native](https://reactnative.dev/) app built using [expo](https://docs.expo.dev/)
+Expo-based React Native client for the expense tracker.
+
+## Development
+
+```bash
+yarn dev       # start Expo
+# or run on specific platforms
+yarn ios
+yarn android
+```
+
+## Environment Variables
+
+Create an `.env` file with the API endpoint:
+
+```bash
+API_URL=
+```
+
+## Features
+
+- Login and signup screens using shared UI components
+- Navigation handled by `expo-router`

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,28 +1,28 @@
-## Getting Started
+# Web App
 
-First, run the development server:
+Next.js front end for the expense tracker. It uses React Native Web so components can be shared with the mobile application.
+
+## Development
 
 ```bash
 yarn dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+The development server starts on http://localhost:3000.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Environment Variables
 
-To create [API routes](https://nextjs.org/docs/app/building-your-application/routing/router-handlers) add an `api/` directory to the `app/` directory with a `route.ts` file. For individual endpoints, create a subfolder in the `api` directory, like `api/hello/route.ts` would map to [http://localhost:3000/api/hello](http://localhost:3000/api/hello).
+Create an `.env` file with the following values:
 
-## Learn More
+```bash
+NEXT_PUBLIC_SUPABASE_URL=
+NEXT_PUBLIC_SUPABASE_ANON_KEY=
+NEXT_PUBLIC_API_URL=
+```
 
-To learn more about Next.js, take a look at the following resources:
+`NEXT_PUBLIC_API_URL` should point to the backend used by the app. Supabase credentials are required for authentication.
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn/foundations/about-nextjs) - an interactive Next.js tutorial.
+## Features
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js/) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_source=github.com&utm_medium=referral&utm_campaign=turborepo-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+- Login and signup screens
+- Dashboard displaying expenses and categories fetched from the API


### PR DESCRIPTION
## Summary
- document project structure, dev workflow and environment variables in root readme
- add setup instructions for the web app
- add expo development guide for the native app

## Testing
- `npx prettier -w README.md apps/web/README.md apps/native/README.md`
- `yarn build` *(fails: fetch failed while generating dashboard page)*

------
https://chatgpt.com/codex/tasks/task_e_688da574a50083209426ded68345985c