### PR TITLE
feat: add shared expense utils

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
     "@radix-ui/react-slot": "^1.2.3",
     "@repo/context": "*",
     "@repo/ui": "*",
+    "@repo/utils": "*",
     "@supabase/ssr": "^0.6.1",
     "@supabase/supabase-js": "^2.53.0",
     "@tailwindcss/postcss": "^4.1.11",

--- a/apps/web/src/components/statistic-block.tsx
+++ b/apps/web/src/components/statistic-block.tsx
@@ -3,6 +3,11 @@
 import { ExpenseItemProps } from "@repo/ui";
 import { useMemo } from "react";
 import {
+  calculateThisMonthSpending,
+  calculateTotalSpending,
+  formatAmount,
+} from "@repo/utils";
+import {
   Card,
   CardDescription,
   CardHeader,
@@ -14,26 +19,16 @@ export interface StatisticBlockProps {
 }
 
 export function StatisticBlock({ expenses }: StatisticBlockProps) {
-  //   TODO Move calculations to shared package
   const totalSpending = useMemo(
-    () => expenses.reduce((sum, e) => sum + e.amount, 0),
+    () => calculateTotalSpending(expenses),
     [expenses],
   );
   const thisMonthSpending = useMemo(
-    () =>
-      expenses.reduce((sum, e) => {
-        const currentMonth = new Date().getMonth();
-        const expenseMonth = new Date(e.date).getMonth();
-        if (currentMonth === expenseMonth) {
-          return sum + e.amount;
-        }
-        return sum;
-      }, 0),
+    () => calculateThisMonthSpending(expenses),
     [expenses],
   );
-  const getFormattedAmount = (amount: number) => amount.toFixed(2);
-  const totalSpendingFormatted = getFormattedAmount(totalSpending);
-  const thisMonthSpendingFormatted = getFormattedAmount(thisMonthSpending);
+  const totalSpendingFormatted = formatAmount(totalSpending);
+  const thisMonthSpendingFormatted = formatAmount(thisMonthSpending);
 
   return (
     <div className="grid grid-cols-1 gap-5 md:grid-cols-2 my-2">

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@repo/utils",
+  "version": "0.0.0",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "clean": "rm -rf dist"
+  },
+  "devDependencies": {
+    "@repo/typescript-config": "*",
+    "tsup": "^8.0.1",
+    "typescript": "5.5.4"
+  },
+  "dependencies": {
+    "@repo/ui": "*"
+  }
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,0 +1,17 @@
+import type { ExpenseItemProps } from "@repo/ui";
+
+export function calculateTotalSpending(expenses: ExpenseItemProps[]): number {
+  return expenses.reduce((sum, e) => sum + e.amount, 0);
+}
+
+export function calculateThisMonthSpending(expenses: ExpenseItemProps[]): number {
+  const currentMonth = new Date().getMonth();
+  return expenses.reduce((sum, e) => {
+    const expenseMonth = new Date(e.date).getMonth();
+    return currentMonth === expenseMonth ? sum + e.amount : sum;
+  }, 0);
+}
+
+export function formatAmount(amount: number): string {
+  return amount.toFixed(2);
+}

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@repo/typescript-config/base.json",
+  "include": ["."],
+  "exclude": ["dist", "build", "node_modules"],
+  "compilerOptions": {
+    "strict": true
+  }
+}

--- a/packages/utils/tsup.config.ts
+++ b/packages/utils/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig, Options } from "tsup";
+
+export default defineConfig((options: Options) => ({
+  entry: {
+    index: "src/index.ts",
+  },
+  clean: true,
+  format: ["cjs", "esm"],
+  dts: true,
+  ...options,
+}));


### PR DESCRIPTION
## Summary
- create reusable expense calculation helpers in new `@repo/utils` package
- use shared helpers in web statistics component

## Testing
- `npm test` *(fails: Missing script "test")*
- `yarn build` *(fails: Export encountered errors on /dashboard/page)*

------
https://chatgpt.com/codex/tasks/task_e_6890ca7ced1c8320b42e0c3f3c326f45