### PR TITLE
fix: forward refs in calendar button

### DIFF
--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -35,25 +35,25 @@ const buttonVariants = cva(
   },
 );
 
-function Button({
-  className,
-  variant,
-  size,
-  asChild = false,
-  ...props
-}: React.ComponentProps<"button"> &
-  VariantProps<typeof buttonVariants> & {
-    asChild?: boolean;
-  }) {
+const Button = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<"button"> &
+    VariantProps<typeof buttonVariants> & {
+      asChild?: boolean;
+    }
+>(({ className, variant, size, asChild = false, ...props }, ref) => {
   const Comp = asChild ? Slot : "button";
 
   return (
     <Comp
+      ref={ref}
       data-slot="button"
       className={cn(buttonVariants({ variant, size, className }))}
       {...props}
     />
   );
-}
+});
+
+Button.displayName = "Button";
 
 export { Button, buttonVariants };

--- a/apps/web/src/components/ui/calendar.tsx
+++ b/apps/web/src/components/ui/calendar.tsx
@@ -172,22 +172,21 @@ function Calendar({
   )
 }
 
-function CalendarDayButton({
-  className,
-  day,
-  modifiers,
-  ...props
-}: React.ComponentProps<typeof DayButton>) {
+const CalendarDayButton = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<typeof DayButton>
+>(({ className, day, modifiers, ...props }, ref) => {
   const defaultClassNames = getDefaultClassNames()
+  const innerRef = React.useRef<HTMLButtonElement>(null)
+  React.useImperativeHandle(ref, () => innerRef.current as HTMLButtonElement)
 
-  const ref = React.useRef<HTMLButtonElement>(null)
   React.useEffect(() => {
-    if (modifiers.focused) ref.current?.focus()
+    if (modifiers.focused) innerRef.current?.focus()
   }, [modifiers.focused])
 
   return (
     <Button
-      ref={ref}
+      ref={innerRef}
       variant="ghost"
       size="icon"
       data-day={day.date.toLocaleDateString()}
@@ -208,6 +207,8 @@ function CalendarDayButton({
       {...props}
     />
   )
-}
+})
+
+CalendarDayButton.displayName = "CalendarDayButton"
 
 export { Calendar, CalendarDayButton }


### PR DESCRIPTION
## Summary
- make Button component forward refs
- forward day button refs in Calendar to silence ref warning

## Testing
- `yarn turbo lint`


------
https://chatgpt.com/codex/tasks/task_e_689117ce6b8083208cf2ca0e7e00d1a4