### PR TITLE
refactor: inline login form with zod validation

### DIFF
--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -41,7 +41,7 @@ export default async function Dashboard() {
   const categories = await getCategories();
 
   return (
-    <div className="flex flex-col gap-5 justify-center px-4 md:px-6">
+    <div className="w-full flex flex-col gap-5 justify-center px-4 md:px-6">
       <TypographyH1>Your Smartest Money Habit Starts Here</TypographyH1>
       <DashboardClient expenses={expenses} categories={categories} />
     </div>

--- a/apps/web/src/components/login-form.tsx
+++ b/apps/web/src/components/login-form.tsx
@@ -4,20 +4,43 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import React, { useState } from "react";
 import { useUser } from "@repo/context/src";
-import { AuthForm, type AuthFormValues } from "@repo/ui";
 import * as process from "process";
+import { z } from "zod";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { TypographyH1 } from "@/components/typography";
 
 export function Form({ onSubmit }: { onSubmit: () => void }) {
   const { setUser } = useUser();
+  const [form, setForm] = useState({ email: "", password: "" });
+  const [errors, setErrors] = useState<Record<string, string>>({});
   const [errorMessage, setErrorMessage] = useState("");
-  const onLogin = async (values: AuthFormValues) => {
+
+  const schema = z.object({
+    email: z.string().email({ message: "Email is invalid" }),
+    password: z.string().min(1, { message: "Password is required" }),
+  });
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const result = schema.safeParse(form);
+    if (!result.success) {
+      const fieldErrors: Record<string, string> = {};
+      result.error.issues.forEach((issue) => {
+        const field = issue.path[0] as string;
+        fieldErrors[field] = issue.message;
+      });
+      setErrors(fieldErrors);
+      return;
+    }
+    setErrors({});
+
     const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/login`, {
       method: "POST",
       body: JSON.stringify({
-        email: values.email,
-        password: values.password,
+        email: result.data.email,
+        password: result.data.password,
       }),
     });
     const data = await response.json();
@@ -30,15 +53,42 @@ export function Form({ onSubmit }: { onSubmit: () => void }) {
       return;
     }
 
-    setUser({ email: values.email, name: values.email });
+    setErrorMessage("");
+    setUser({ email: result.data.email, name: result.data.email });
     onSubmit && onSubmit();
   };
+
   return (
-    <AuthForm
-      submitButtonText="Login"
-      onSubmit={onLogin}
-      errorMessage={errorMessage}
-    />
+    <form onSubmit={handleSubmit} className="grid gap-4">
+      <div className="grid gap-2">
+        <Label htmlFor="email">Email</Label>
+        <Input
+          id="email"
+          name="email"
+          type="email"
+          value={form.email}
+          onChange={(e) => setForm({ ...form, email: e.target.value })}
+        />
+        {errors.email && <p className="text-sm text-red-500">{errors.email}</p>}
+      </div>
+      <div className="grid gap-2">
+        <Label htmlFor="password">Password</Label>
+        <Input
+          id="password"
+          name="password"
+          type="password"
+          value={form.password}
+          onChange={(e) => setForm({ ...form, password: e.target.value })}
+        />
+        {errors.password && (
+          <p className="text-sm text-red-500">{errors.password}</p>
+        )}
+      </div>
+      {errorMessage && (
+        <p className="text-sm text-red-500 text-center">{errorMessage}</p>
+      )}
+      <Button type="submit">Login</Button>
+    </form>
   );
 }
 

--- a/apps/web/src/components/typography/TypographyH1.tsx
+++ b/apps/web/src/components/typography/TypographyH1.tsx
@@ -10,7 +10,7 @@ export function TypographyH1({
     <h1
       className={cn(
         className,
-        "scroll-m-20 text-center text-2xl md:text-4xl font-extrabold tracking-tight text-balance",
+        "my-4 scroll-m-20 text-center text-2xl md:text-4xl font-extrabold tracking-tight text-balance",
       )}
       {...props}
     >


### PR DESCRIPTION
## Summary
- rewrite web login form to use local inputs and zod validation instead of AuthForm

## Testing
- `cd apps/web && yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_689212cc0ce48320923686c77660204e